### PR TITLE
Specify remote host address and port using command line arguments

### DIFF
--- a/reverse-proxy/proxy.go
+++ b/reverse-proxy/proxy.go
@@ -1,134 +1,132 @@
 package main
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/pem"
-	"fmt"
-	"io"
-	"log"
-	"net"
-	"os"
+  "crypto/tls"
+  "crypto/x509"
+  "encoding/pem"
+  "fmt"
+  "io"
+  "log"
+  "net"
+  "os"
 
-	"github.com/alexflint/go-arg"
+  "github.com/alexflint/go-arg"
 )
 
 func loadCertificate(path string) (*x509.Certificate, error) {
-	dat, err := os.ReadFile(path)
-	if err != nil {
-		log.Println(err)
-		return nil, err
-	}
+  dat, err := os.ReadFile(path)
+  if err != nil {
+    log.Println(err)
+    return nil, err
+  }
 
-	pemblock, _ := pem.Decode(dat)
-	cert, err := x509.ParseCertificate(pemblock.Bytes)
-	if err != nil {
-		log.Println(err)
-		return nil, err
-	}
-	return cert, nil
+  pemblock, _ := pem.Decode(dat)
+  cert, err := x509.ParseCertificate(pemblock.Bytes)
+  if err != nil {
+    log.Println(err)
+    return nil, err
+  }
+  return cert, nil
 }
 
 func generateCertPool(certs []x509.Certificate) (*x509.CertPool, error) {
-	pool := x509.NewCertPool()
+  pool := x509.NewCertPool()
 
-	for _, c := range certs {
-		pool.AddCert(&c)
-	}
+  for _, c := range certs {
+    pool.AddCert(&c)
+  }
 
-	return pool, nil
+  return pool, nil
 }
 
 func reverseConnect(front net.Conn, targetAddr string, targetPort string) {
-	address := targetAddr + ":" + targetPort
-	back, err := net.Dial("tcp4", address)
-	if err != nil {
-		fmt.Println(err)
-		front.Write([]byte(err.Error()))
-		front.Close()
-		return
-	}
+  address := targetAddr + ":" + targetPort
+  back, err := net.Dial("tcp4", address)
+  if err != nil {
+    fmt.Println(err)
+    front.Write([]byte(err.Error()))
+    front.Close()
+    return
+  }
 
-	go io.Copy(front, back)
-	io.Copy(back, front)
-
+  go io.Copy(front, back)
+  io.Copy(back, front)
 }
 
 func handleConnections(listener net.Listener, targetAddr string, targetPort string) {
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			fmt.Println("Error accepting connection:", err)
-			continue
-		}
+  for {
+    conn, err := listener.Accept()
+    if err != nil {
+      fmt.Println("Error accepting connection:", err)
+      continue
+    }
 
-		t := conn.(*tls.Conn)
-		t.Handshake()
-		peers := t.ConnectionState().PeerCertificates
+    t := conn.(*tls.Conn)
+    t.Handshake()
+    peers := t.ConnectionState().PeerCertificates
 
-		if len(peers) != 1 {
-			fmt.Println("[!] Was not presented a cert by the connection")
-			conn.Write([]byte("Failed to verify certificate, register at keys.lowlevel.tv.\n"))
-			conn.Close()
-			continue
-		}
+    if len(peers) != 1 {
+      fmt.Println("[!] Was not presented a cert by the connection")
+      conn.Write([]byte("Failed to verify certificate, register at keys.lowlevel.tv.\n"))
+      conn.Close()
+      continue
+    }
 
-		username := peers[0].Subject.Organization[0]
-		fmt.Printf("[!] %s connected\n", username)
+    username := peers[0].Subject.Organization[0]
+    fmt.Printf("[!] %s connected\n", username)
 
-		go reverseConnect(conn, targetAddr, targetPort)
-
-	}
+    go reverseConnect(conn, targetAddr, targetPort)
+  }
 }
 
 func main() {
 
-	var args struct {
-		CertFile         string
-		KeyFile          string
-		RootCAFile       string
-		RemoteTargetAddr string
-		RemoteTargetPort string
-	}
+  var args struct {
+    CertFile         string
+    KeyFile          string
+    RootCAFile       string
+    RemoteTargetAddr string
+    RemoteTargetPort string
+  }
 
-	arg.MustParse(&args)
+  arg.MustParse(&args)
 
-	fmt.Println("[+] Starting Twitch Chat Reverse Proxy")
+  fmt.Println("[+] Starting Twitch Chat Reverse Proxy")
 
-	fmt.Println("[+] Loading key information")
-	cer, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+  fmt.Println("[+] Loading key information")
+  cer, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
+  if err != nil {
+    log.Println(err)
+    return
+  }
 
-	rootCAcert, err := loadCertificate(args.RootCAFile)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+  rootCAcert, err := loadCertificate(args.RootCAFile)
+  if err != nil {
+    log.Println(err)
+    return
+  }
 
-	fmt.Println("[+] Loading RootCA certificate")
-	pool, err := generateCertPool([]x509.Certificate{*rootCAcert})
-	if err != nil {
-		log.Println(err)
-		return
-	}
+  fmt.Println("[+] Loading RootCA certificate")
+  pool, err := generateCertPool([]x509.Certificate{*rootCAcert})
+  if err != nil {
+    log.Println(err)
+    return
+  }
 
-	config := &tls.Config{
-		Certificates: []tls.Certificate{cer},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		RootCAs:      pool,
-		ClientCAs:    pool,
-	}
+  config := &tls.Config{
+    Certificates: []tls.Certificate{cer},
+    ClientAuth:   tls.RequireAndVerifyClientCert,
+    RootCAs:      pool,
+    ClientCAs:    pool,
+  }
 
-	sock, err := tls.Listen("tcp", ":4444", config)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+  sock, err := tls.Listen("tcp", ":4444", config)
+  if err != nil {
+    log.Println(err)
+    return
+  }
 
-	defer sock.Close()
+  defer sock.Close()
 
-	handleConnections(sock, args.RemoteTargetAddr, args.RemoteTargetPort)
+  handleConnections(sock, args.RemoteTargetAddr, args.RemoteTargetPort)
 }

--- a/reverse-proxy/proxy.go
+++ b/reverse-proxy/proxy.go
@@ -131,5 +131,4 @@ func main() {
 	defer sock.Close()
 
 	handleConnections(sock, args.RemoteTargetAddr, args.RemoteTargetPort)
-
 }

--- a/reverse-proxy/proxy.go
+++ b/reverse-proxy/proxy.go
@@ -1,133 +1,135 @@
 package main
 
 import (
-  "crypto/tls"
-  "crypto/x509"
-  "encoding/pem"
-  "fmt"
-  "log"
-  "os"
-  "net"
-  "io"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
 
-  "github.com/alexflint/go-arg"
+	"github.com/alexflint/go-arg"
 )
 
 func loadCertificate(path string) (*x509.Certificate, error) {
-  dat, err := os.ReadFile(path)
-  if err != nil {
-    log.Println(err)
-    return nil, err
-  }
+	dat, err := os.ReadFile(path)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
 
-  pemblock, _ := pem.Decode(dat)
-  cert, err := x509.ParseCertificate(pemblock.Bytes)
-  if (err != nil) {
-    log.Println(err)
-    return nil, err
-  }
-  return cert, nil 
+	pemblock, _ := pem.Decode(dat)
+	cert, err := x509.ParseCertificate(pemblock.Bytes)
+	if err != nil {
+		log.Println(err)
+		return nil, err
+	}
+	return cert, nil
 }
 
 func generateCertPool(certs []x509.Certificate) (*x509.CertPool, error) {
-  pool := x509.NewCertPool()
+	pool := x509.NewCertPool()
 
-  for _, c := range certs {
-    pool.AddCert(&c)
-  }
+	for _, c := range certs {
+		pool.AddCert(&c)
+	}
 
-  return pool, nil
+	return pool, nil
 }
 
-func reverseConnect(front net.Conn) {
-  // TODO: params
-  back, err := net.Dial("tcp4", "localhost:8080")
-  if (err != nil) {
-    fmt.Println(err)
-    front.Write([]byte(err.Error()))
-    front.Close()
-    return
-  }
+func reverseConnect(front net.Conn, targetAddr string, targetPort string) {
+	address := targetAddr + ":" + targetPort
+	back, err := net.Dial("tcp4", address)
+	if err != nil {
+		fmt.Println(err)
+		front.Write([]byte(err.Error()))
+		front.Close()
+		return
+	}
 
-  go io.Copy(front, back)
-  io.Copy(back, front)
+	go io.Copy(front, back)
+	io.Copy(back, front)
 
 }
 
-func handleConnections(listener net.Listener) {
-  for {
-    conn, err := listener.Accept()
-    if err != nil {
-      fmt.Println("Error accepting connection:", err)
-      continue
-    }
+func handleConnections(listener net.Listener, targetAddr string, targetPort string) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Println("Error accepting connection:", err)
+			continue
+		}
 
-    t := conn.(*tls.Conn)
-    t.Handshake()
-    peers := t.ConnectionState().PeerCertificates
-        
-    if (len(peers) != 1) {
-      fmt.Println("[!] Was not presented a cert by the connection")
-      conn.Write([]byte("Failed to verify certificate, register at keys.lowlevel.tv.\n"))
-      conn.Close()
-      continue
-    }
+		t := conn.(*tls.Conn)
+		t.Handshake()
+		peers := t.ConnectionState().PeerCertificates
 
-    username := peers[0].Subject.Organization[0]
-    fmt.Printf("[!] %s connected\n", username)
+		if len(peers) != 1 {
+			fmt.Println("[!] Was not presented a cert by the connection")
+			conn.Write([]byte("Failed to verify certificate, register at keys.lowlevel.tv.\n"))
+			conn.Close()
+			continue
+		}
 
-    go reverseConnect(conn)
+		username := peers[0].Subject.Organization[0]
+		fmt.Printf("[!] %s connected\n", username)
 
-  }
+		go reverseConnect(conn, targetAddr, targetPort)
+
+	}
 }
 
-func main()  {
+func main() {
 
-  var args struct {
-    CertFile string
-    KeyFile string
-    RootCAFile string
-  }
+	var args struct {
+		CertFile         string
+		KeyFile          string
+		RootCAFile       string
+		RemoteTargetAddr string
+		RemoteTargetPort string
+	}
 
-  arg.MustParse(&args)
+	arg.MustParse(&args)
 
-  fmt.Println("[+] Starting Twitch Chat Reverse Proxy");
+	fmt.Println("[+] Starting Twitch Chat Reverse Proxy")
 
-  fmt.Println("[+] Loading key information");
-  cer, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
-  if err != nil {
-    log.Println(err)
-    return
-  }
+	fmt.Println("[+] Loading key information")
+	cer, err := tls.LoadX509KeyPair(args.CertFile, args.KeyFile)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
-  rootCAcert, err := loadCertificate(args.RootCAFile)
-  if err != nil {
-    log.Println(err)
-    return
-  }
+	rootCAcert, err := loadCertificate(args.RootCAFile)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
-  fmt.Println("[+] Loading RootCA certificate");
-  pool, err := generateCertPool([]x509.Certificate{*rootCAcert})
-  if err != nil {
-    log.Println(err)
-    return
-  }
+	fmt.Println("[+] Loading RootCA certificate")
+	pool, err := generateCertPool([]x509.Certificate{*rootCAcert})
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
-  config := &tls.Config{
-    Certificates: []tls.Certificate{cer},
-    ClientAuth: tls.RequireAndVerifyClientCert,
-    RootCAs: pool,
-    ClientCAs: pool,
-  }
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cer},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		RootCAs:      pool,
+		ClientCAs:    pool,
+	}
 
-  sock, err := tls.Listen("tcp", ":4444", config)
-  if err != nil {
-    log.Println(err)
-    return
-  }
+	sock, err := tls.Listen("tcp", ":"+args.RemoteTargetPort, config)
+	if err != nil {
+		log.Println(err)
+		return
+	}
 
-  defer sock.Close()
+	defer sock.Close()
 
-  handleConnections(sock)
-  
+	handleConnections(sock, args.RemoteTargetAddr, args.RemoteTargetPort)
+
 }

--- a/reverse-proxy/proxy.go
+++ b/reverse-proxy/proxy.go
@@ -122,7 +122,7 @@ func main() {
 		ClientCAs:    pool,
 	}
 
-	sock, err := tls.Listen("tcp", ":"+args.RemoteTargetPort, config)
+	sock, err := tls.Listen("tcp", ":4444", config)
 	if err != nil {
 		log.Println(err)
 		return


### PR DESCRIPTION
### Summary
The title says it all. Add the ability to specify these fields using command-line arguments alongside CertFile, KeyFile, etc. Remove the TODO comment. Code should work as expected. 

Previously, 'localhost' was the only available address and hardcoded, as well as port '8080'. This allows users to change remote addresses and ports dynamically. 

### Changes
I added two fields to the 'args' struct:
1. ``` RemoteTargetAddr string ```
2. ``` RemoteTargetPort string ```

```handleConnections()``` now takes two extra parameters, targetAddr and targetPort and passes them to ```reverseConnect()```.
Similarly, ```reverseConnect()``` now takes two extra parameters, targetAddr and targetPort.

In ```reverseConnect()```, instead of using ```net.Dial``` hardcoded to localhost:8080, it sets to the targetAddr + ":" + targetPort.

**P.S.** This is my first contribution to someone else's repository, so hopefully I made some useful changes.